### PR TITLE
Don't delete ~/.oh-my-zsh, just rename it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ if uname -a | grep -qi 'Ubuntu'; then
   sudo chsh -s "$(which zsh)" "$(whoami)"
 
   echo 'Installing oh-my-zsh...'
-  rm -rf ~/.oh-my-zsh
+  mv ~/.oh-my-zsh ~/.oh-my-zsh.old
   git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 
   echo 'Installing powerline-fonts...'
@@ -101,7 +101,7 @@ if uname -a | grep -qi 'Darwin'; then
   sudo chsh -s "$(which zsh)" "$(whoami)"
 
   echo 'Installing oh-my-zsh...'
-  rm -rf ~/.oh-my-zsh
+  mv ~/.oh-my-zsh ~/.oh-my-zsh.old
   git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 
   echo 'Installing powerline-fonts...'


### PR DESCRIPTION
Don't delete `~/.oh-my-zsh` in the install script; just rename it. Thanks @mark-tai for spotting this.

Fixes: https://github.com/stepchowfun/dotfiles/issues/1