### PR TITLE
Disable scrolling in Alacritty (since tmux already has scrolling)

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -56,7 +56,7 @@ window:
 scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.
-  history: 10000
+  history: 0
 
   # Number of lines the viewport will move for every line scrolled when
   # scrollback is enabled (history > 0).


### PR DESCRIPTION
Disable scrolling in Alacritty (since tmux already has scrolling). This makes Alacritty use far less memory (much bigger savings than I would expect).