### PR TITLE
Make `gd` center the definition in the window

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -83,7 +83,7 @@ nmap <silent> <BS> :TmuxNavigateLeft<CR>
 
 " LanguageClient shortcuts
 nmap <silent> K :call LanguageClient#textDocument_hover()<CR>
-nmap <silent> gd :call LanguageClient#textDocument_definition()<CR>
+nmap <silent> gd :call LanguageClient#textDocument_definition()<CR>zz
 
 " Set the airline theme.
 let g:airline_theme = 'base16'


### PR DESCRIPTION
Make `gd` center the definition in the window.