### PR TITLE
Set `hide_when_typing: true` in the Alacritty config

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -375,7 +375,7 @@ font:
   # Record all characters and escape sequences as test data.
   #ref_test: false
 
-#mouse:
+mouse:
   # Click settings
   #
   # The `double_click` and `triple_click` settings control the time
@@ -385,7 +385,7 @@ font:
   #triple_click: { threshold: 300 }
 
   # If this is `true`, the cursor is temporarily hidden when typing.
-  #hide_when_typing: false
+  hide_when_typing: true
 
   #url:
     # URL launcher


### PR DESCRIPTION
Set `hide_when_typing: true` in the Alacritty config.