### PR TITLE
Make the installer script more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ## Installation
 
-Just run this:
+Run this command:
 
 ```sh
 curl https://www.stephanboyer.com/dotfiles -LSfs | sh
 ```
 
-Then use [Alacritty](https://github.com/jwilm/alacritty) as your terminal.
+Then use [Alacritty](https://github.com/jwilm/alacritty) as your terminal. Other terminals such as Termianl (macOS) and iTerm2 are known to work, but the installer script only installs a configuration for Alacritty.
 
 **NOTE:** The installer script will overwrite existing dotfiles and other configuration. Use at your own risk!

--- a/install.sh
+++ b/install.sh
@@ -1,194 +1,199 @@
 #!/usr/bin/env sh
-set -eu -o pipefail
 
-DIR="$(cd "$(dirname "$0")"; pwd)"
+# We wrap everything in parentheses for two reasons:
+# 1. To prevent the shell from executing only a prefix of the script if the download is interrupted
+# 2. To ensure that any working directory changes with `cd` are local to this script and don't
+#    affect the calling user's shell
+(
+  DIR="$(cd "$(dirname "$0")"; pwd)"
 
-if uname -a | grep -qi 'Ubuntu'; then
-  echo 'Ubuntu detected.'
+  if uname -a | grep -qi 'Ubuntu'; then
+    echo 'Ubuntu detected.'
 
-  echo 'Updating package lists...'
-  DEBIAN_FRONTEND=noninteractive sudo apt-get -y update < /dev/tty
+    echo 'Updating package lists...'
+    DEBIAN_FRONTEND=noninteractive sudo apt-get -y update < /dev/tty
 
-  echo 'Installing Alacritty...'
-  DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:mmstick76/alacritty
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y alacritty < /dev/tty
+    echo 'Installing Alacritty...'
+    DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:mmstick76/alacritty
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y alacritty < /dev/tty
 
-  echo 'Installing Git...'
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y git < /dev/tty
+    echo 'Installing Git...'
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y git < /dev/tty
 
-  echo 'Installing zsh...'
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y zsh < /dev/tty
+    echo 'Installing zsh...'
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y zsh < /dev/tty
 
-  echo 'Setting the login shell to zsh...'
-  sudo chsh -s "$(which zsh)" "$(whoami)" < /dev/tty
+    echo 'Setting the login shell to zsh...'
+    sudo chsh -s "$(which zsh)" "$(whoami)" < /dev/tty
 
-  echo 'Installing oh-my-zsh...'
-  rm -rf ~/.oh-my-zsh
-  git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
+    echo 'Installing oh-my-zsh...'
+    rm -rf ~/.oh-my-zsh
+    git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 
-  echo 'Installing the `Input` font...'
-  mkdir -p ~/.local/share/fonts
-  cp input-font/Input_Fonts/Input/* ~/.local/share/fonts
+    echo 'Installing the `Input` font...'
+    mkdir -p ~/.local/share/fonts
+    cp input-font/Input_Fonts/Input/* ~/.local/share/fonts
 
-  if which fc-cache >/dev/null 2>&1 ; then
-    echo "Resetting font cache..."
-    fc-cache -f ~/.local/share/fonts
+    if which fc-cache >/dev/null 2>&1 ; then
+      echo "Resetting font cache..."
+      fc-cache -f ~/.local/share/fonts
+    fi
+
+    echo 'Installing tmux...'
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y tmux < /dev/tty
+
+    echo 'Installing Python3...'
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python3-pip < /dev/tty
+
+    echo 'Installing Python3 support for neovim...'
+    pip3 install --user neovim
+
+    echo 'Installing neovim...'
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y software-properties-common < /dev/tty
+    DEBIAN_FRONTEND=noninteractive sudo add-apt-repository -y ppa:neovim-ppa/unstable < /dev/tty
+    DEBIAN_FRONTEND=noninteractive sudo apt-get update -y < /dev/tty
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y neovim < /dev/tty
+
+    echo 'Installing vim-plug...'
+    curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
+          https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+
+    echo 'Downloading submodules...'
+    (cd $DIR && git submodule update --init)
+
+    echo 'Installing dotfiles...'
+    cp  "$DIR/.tmux.conf" ~/.tmux.conf
+    cp  "$DIR/.zshrc" ~/.zshrc
+    rm -rf ~/.config/base16-shell
+    mkdir -p ~/.config/base16-shell
+    cp -r "$DIR/.config/base16-shell" ~/.config
+    rm -rf ~/.config/nvim
+    mkdir -p ~/.config/nvim
+    cp -r "$DIR/.config/nvim" ~/.config
+    rm -rf ~/.config/alacritty
+    mkdir -p ~/.config/alacritty
+    cp -r "$DIR/.config/alacritty" ~/.config
+
+    echo 'Installing vim plugins...'
+    nvim -c PlugInstall -c qa
+
+    echo 'Installing color scheme...'
+    cp "$DIR/base16-circus-scheme/circus/scripts/base16-circus.sh" ~/.config/base16-shell/scripts
+    cp "$DIR/base16-circus-scheme/circus/colors/base16-circus.vim" ~/.local/share/nvim/plugged/base16-vim/colors
+
+    echo 'Patching the vim color scheme to not set the background color...'
+    echo 'This allows vim to use the background set by tmux, which is configured'
+    echo 'to use a lighter background for panes that are not in focus.'
+    sed -E -i.bak 's/[ \t]*let[ \t]+s:cterm00[ \t]*=.*$/let s:cterm00 = "none"/' ~/.local/share/nvim/plugged/base16-vim/colors/base16-circus.vim
+
+    echo 'Setting base16-shell color scheme...'
+    zsh -ic base16_circus
+
+    echo 'Reloading tmux config...'
+    tmux source-file ~/.tmux.conf || true
+
+    echo 'Installing ripgrep...'
+    curl -L -o ripgrep.tar.gz https://github.com/BurntSushi/ripgrep/releases/download/0.5.1/ripgrep-0.5.1-x86_64-unknown-linux-musl.tar.gz
+    mkdir ripgrep
+    tar -xzf ripgrep.tar.gz -C ripgrep --strip-components=1
+    sudo cp ripgrep/rg /usr/local/bin < /dev/tty
+    rm -rf ripgrep ripgrep.tar.gz
+
+    echo 'Done.'
+    exit
   fi
 
-  echo 'Installing tmux...'
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y tmux < /dev/tty
+  if uname -a | grep -qi 'Darwin'; then
+    echo 'macOS detected.'
 
-  echo 'Installing Python3...'
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python3-pip < /dev/tty
+    echo 'Installing Homebrew...'
+    which brew > /dev/null || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-  echo 'Installing Python3 support for neovim...'
-  pip3 install --user neovim
+    echo 'Updating Homebrew...'
+    brew update
 
-  echo 'Installing neovim...'
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y software-properties-common < /dev/tty
-  DEBIAN_FRONTEND=noninteractive sudo add-apt-repository -y ppa:neovim-ppa/unstable < /dev/tty
-  DEBIAN_FRONTEND=noninteractive sudo apt-get update -y < /dev/tty
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y neovim < /dev/tty
+    echo 'Installing Alacritty...'
+    stat /Applications/Alacritty.app > /dev/null || brew cask install alacritty
 
-  echo 'Installing vim-plug...'
-  curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
-        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    echo 'Installing Git...'
+    brew ls --versions git || brew install git
 
-  echo 'Downloading submodules...'
-  (cd $DIR && git submodule update --init)
+    echo 'Installing zsh...'
+    brew ls --versions zsh || brew install zsh
+    brew ls --versions zsh-completions || brew install zsh-completions
 
-  echo 'Installing dotfiles...'
-  cp  "$DIR/.tmux.conf" ~/.tmux.conf
-  cp  "$DIR/.zshrc" ~/.zshrc
-  rm -rf ~/.config/base16-shell
-  mkdir -p ~/.config/base16-shell
-  cp -r "$DIR/.config/base16-shell" ~/.config
-  rm -rf ~/.config/nvim
-  mkdir -p ~/.config/nvim
-  cp -r "$DIR/.config/nvim" ~/.config
-  rm -rf ~/.config/alacritty
-  mkdir -p ~/.config/alacritty
-  cp -r "$DIR/.config/alacritty" ~/.config
+    echo 'Setting the login shell to zsh...'
+    sudo sh -c "grep -qi \"$(which zsh)\" /etc/shells || echo \"$(which zsh)\" >> /etc/shells" < /dev/tty
+    sudo chsh -s "$(which zsh)" "$(whoami)" < /dev/tty
 
-  echo 'Installing vim plugins...'
-  nvim -c PlugInstall -c qa
+    echo 'Installing oh-my-zsh...'
+    rm -rf ~/.oh-my-zsh
+    git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 
-  echo 'Installing color scheme...'
-  cp "$DIR/base16-circus-scheme/circus/scripts/base16-circus.sh" ~/.config/base16-shell/scripts
-  cp "$DIR/base16-circus-scheme/circus/colors/base16-circus.vim" ~/.local/share/nvim/plugged/base16-vim/colors
+    echo 'Installing the `Input` font...'
+    cp input-font/Input_Fonts/Input/* ~/Library/Fonts
 
-  echo 'Patching the vim color scheme to not set the background color...'
-  echo 'This allows vim to use the background set by tmux, which is configured'
-  echo 'to use a lighter background for panes that are not in focus.'
-  sed -E -i.bak 's/[ \t]*let[ \t]+s:cterm00[ \t]*=.*$/let s:cterm00 = "none"/' ~/.local/share/nvim/plugged/base16-vim/colors/base16-circus.vim
+    echo 'Installing tmux...'
+    brew ls --versions tmux || brew install tmux
+    brew ls --versions reattach-to-user-namespace || brew install reattach-to-user-namespace
 
-  echo 'Setting base16-shell color scheme...'
-  zsh -ic base16_circus
+    # NOTE: Only the macOS version of this script installs tmuxinator.
+    echo 'Installing tmuxinator...'
+    brew ls --versions tmuxinator || brew install tmuxinator
 
-  echo 'Reloading tmux config...'
-  tmux source-file ~/.tmux.conf || true
+    echo 'Installing Python3...'
+    brew ls --versions python || brew install python
 
-  echo 'Installing ripgrep...'
-  curl -L -o ripgrep.tar.gz https://github.com/BurntSushi/ripgrep/releases/download/0.5.1/ripgrep-0.5.1-x86_64-unknown-linux-musl.tar.gz
-  mkdir ripgrep
-  tar -xzf ripgrep.tar.gz -C ripgrep --strip-components=1
-  sudo cp ripgrep/rg /usr/local/bin < /dev/tty
-  rm -rf ripgrep ripgrep.tar.gz
+    echo 'Installing Python3 support for neovim...'
+    pip3 install --user neovim
 
-  echo 'Done.'
-  exit
-fi
+    echo 'Installing neovim...'
+    brew ls --versions neovim || brew install neovim
 
-if uname -a | grep -qi 'Darwin'; then
-  echo 'macOS detected.'
+    echo 'Installing vim-plug...'
+    curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
+          https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 
-  echo 'Installing Homebrew...'
-  which brew > /dev/null || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    echo 'Downloading submodules...'
+    (cd $DIR && git submodule update --init)
 
-  echo 'Updating Homebrew...'
-  brew update
+    echo 'Installing dotfiles...'
+    cp  "$DIR/.tmux.conf" ~/.tmux.conf
+    cp  "$DIR/.zshrc" ~/.zshrc
+    rm -rf ~/.config/base16-shell
+    mkdir -p ~/.config/base16-shell
+    cp -r "$DIR/.config/base16-shell" ~/.config
+    rm -rf ~/.config/nvim
+    mkdir -p ~/.config/nvim
+    cp -r "$DIR/.config/nvim" ~/.config
+    rm -rf ~/.config/alacritty
+    mkdir -p ~/.config/alacritty
+    cp -r "$DIR/.config/alacritty" ~/.config
 
-  echo 'Installing Alacritty...'
-  stat /Applications/Alacritty.app > /dev/null || brew cask install alacritty
+    echo 'Installing vim plugins...'
+    nvim -c PlugInstall -c qa
 
-  echo 'Installing Git...'
-  brew ls --versions git || brew install git
+    echo 'Installing color scheme...'
+    cp "$DIR/base16-circus-scheme/circus/scripts/base16-circus.sh" ~/.config/base16-shell/scripts
+    cp "$DIR/base16-circus-scheme/circus/colors/base16-circus.vim" ~/.local/share/nvim/plugged/base16-vim/colors
 
-  echo 'Installing zsh...'
-  brew ls --versions zsh || brew install zsh
-  brew ls --versions zsh-completions || brew install zsh-completions
+    echo 'Patching the vim color scheme to not set the background color...'
+    echo 'This allows vim to use the background set by tmux, which is configured'
+    echo 'to use a lighter background for panes that are not in focus.'
+    sed -E -i.bak 's/[ \t]*let[ \t]+s:cterm00[ \t]*=.*$/let s:cterm00 = "none"/' ~/.local/share/nvim/plugged/base16-vim/colors/base16-circus.vim
 
-  echo 'Setting the login shell to zsh...'
-  sudo sh -c "grep -qi \"$(which zsh)\" /etc/shells || echo \"$(which zsh)\" >> /etc/shells" < /dev/tty
-  sudo chsh -s "$(which zsh)" "$(whoami)" < /dev/tty
+    echo 'Setting base16-shell color scheme...'
+    zsh -ic base16_circus
 
-  echo 'Installing oh-my-zsh...'
-  rm -rf ~/.oh-my-zsh
-  git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
+    echo 'Reloading tmux config...'
+    tmux source-file ~/.tmux.conf || true
 
-  echo 'Installing the `Input` font...'
-  cp input-font/Input_Fonts/Input/* ~/Library/Fonts
+    echo 'Installing ripgrep...'
+    brew ls --versions ripgrep || brew install ripgrep
 
-  echo 'Installing tmux...'
-  brew ls --versions tmux || brew install tmux
-  brew ls --versions reattach-to-user-namespace || brew install reattach-to-user-namespace
+    echo 'Done.'
+    exit
+  fi
 
-  # NOTE: Only the macOS version of this script installs tmuxinator.
-  echo 'Installing tmuxinator...'
-  brew ls --versions tmuxinator || brew install tmuxinator
-
-  echo 'Installing Python3...'
-  brew ls --versions python || brew install python
-
-  echo 'Installing Python3 support for neovim...'
-  pip3 install --user neovim
-
-  echo 'Installing neovim...'
-  brew ls --versions neovim || brew install neovim
-
-  echo 'Installing vim-plug...'
-  curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
-        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-
-  echo 'Downloading submodules...'
-  (cd $DIR && git submodule update --init)
-
-  echo 'Installing dotfiles...'
-  cp  "$DIR/.tmux.conf" ~/.tmux.conf
-  cp  "$DIR/.zshrc" ~/.zshrc
-  rm -rf ~/.config/base16-shell
-  mkdir -p ~/.config/base16-shell
-  cp -r "$DIR/.config/base16-shell" ~/.config
-  rm -rf ~/.config/nvim
-  mkdir -p ~/.config/nvim
-  cp -r "$DIR/.config/nvim" ~/.config
-  rm -rf ~/.config/alacritty
-  mkdir -p ~/.config/alacritty
-  cp -r "$DIR/.config/alacritty" ~/.config
-
-  echo 'Installing vim plugins...'
-  nvim -c PlugInstall -c qa
-
-  echo 'Installing color scheme...'
-  cp "$DIR/base16-circus-scheme/circus/scripts/base16-circus.sh" ~/.config/base16-shell/scripts
-  cp "$DIR/base16-circus-scheme/circus/colors/base16-circus.vim" ~/.local/share/nvim/plugged/base16-vim/colors
-
-  echo 'Patching the vim color scheme to not set the background color...'
-  echo 'This allows vim to use the background set by tmux, which is configured'
-  echo 'to use a lighter background for panes that are not in focus.'
-  sed -E -i.bak 's/[ \t]*let[ \t]+s:cterm00[ \t]*=.*$/let s:cterm00 = "none"/' ~/.local/share/nvim/plugged/base16-vim/colors/base16-circus.vim
-
-  echo 'Setting base16-shell color scheme...'
-  zsh -ic base16_circus
-
-  echo 'Reloading tmux config...'
-  tmux source-file ~/.tmux.conf || true
-
-  echo 'Installing ripgrep...'
-  brew ls --versions ripgrep || brew install ripgrep
-
-  echo 'Done.'
-  exit
-fi
-
-echo 'This operating system is not supported.'
+  echo 'This operating system is not supported.'
+)


### PR DESCRIPTION
Make the installer script more robust in two ways:

1. Make it more portable by removing `set -eu -o pipefail`. I'm sad about this, but now the script should run with Dash (Ubuntu's default shell).
2. Wrap everything in parentheses for reasons noted in the comment in the code.