### PR TITLE
Don't use Powerline symbols since they don't seem to render well in the Input font

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -90,7 +90,7 @@ nmap <silent> gd :call LanguageClient#textDocument_definition()<CR>zz
 
 " Set the airline theme.
 let g:airline_theme = 'base16'
-let g:airline_powerline_fonts = 1
+let g:airline_powerline_fonts = 0
 
 " Clear highlighting with Esc.
 nmap <silent> <esc> :noh<return>


### PR DESCRIPTION
Don't use Powerline symbols since they don't seem to render well in the Input font.