### PR TITLE
Change a fatal non-breaking space into a regular space

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -135,7 +135,7 @@ function update-repo {
     git fetch origin "$1:$1"
   fi
 
-  git fetch --prune
+  git fetch --prune
 }
 
 function gr {


### PR DESCRIPTION
Change a fatal non-breaking space into a regular space. I have no idea how this happened! I was wondering why my `update-repo` function had stopped working...