### PR TITLE
Remove the `base16-circus-scheme` submodule since it's now included upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule ".config/base16-shell"]
 	path = .config/base16-shell
 	url = https://github.com/chriskempson/base16-shell.git
-[submodule "base16-circus-scheme"]
-	path = base16-circus-scheme
-	url = https://github.com/stepchowfun/base16-circus-scheme.git


### PR DESCRIPTION
Remove the `base16-circus-scheme` submodule since it's now included upstream.

**Status:** Ready

**Fixes:** N/A