### PR TITLE
Make `replace` work in hidden files and directories except `.git/`

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -80,7 +80,7 @@ function replace {
   #   rg --null --files-with-matches "$1" | xargs --null -I % sed --regexp-extended --in-place "s/$1/$2/g" %
 
   # macOS version:
-  rg --null --files-with-matches "$1" | xargs -0 -I % sed -E -I '' "s/$1/$2/g" %
+  rg --null --hidden --glob '!.git/' --files-with-matches "$1" | xargs -0 -I % sed -E -I '' "s/$1/$2/g" %
 }
 
 function die {


### PR DESCRIPTION
Make `replace` work in hidden files and directories except `.git/`.

**Status:** Ready

**Fixes:** N/A