### PR TITLE
Set `outline.collapseItems` to `alwaysCollapse` in the VSCode settings

### DIFF
--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -9,5 +9,6 @@
   "editor.minimap.enabled": false,
   "[rust]": {
     "editor.tabSize": 4
-  }
+  },
+  "outline.collapseItems": "alwaysCollapse"
 }


### PR DESCRIPTION
Set `outline.collapseItems` to `alwaysCollapse` in the VSCode settings.

**Status:** Ready

**Fixes:** N/A