### PR TITLE
Enable reading from the remote Toast cache for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
       with:
         tasks: install
         docker_repo: stephanmisc/toast
-        read_remote_cache: ${{ github.event_name == 'push' }}
+        read_remote_cache: true
         write_remote_cache: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Enable reading from the remote Toast cache for pull requests.

**Status:** Ready

**Fixes:** N/A