### PR TITLE
Remove some superfluous quotes in the Visual Studio Code configuration

### DIFF
--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -1,7 +1,7 @@
 {
   "vim.useSystemClipboard": true,
   "telemetry.telemetryLevel": "off",
-  "editor.fontFamily": "Berkeley Mono, Menlo, Monaco, 'Courier New', monospace",
+  "editor.fontFamily": "Berkeley Mono, Menlo, Monaco, Courier New, monospace",
   "editor.fontSize": 15,
   "editor.tabSize": 2,
   "editor.detectIndentation": false,


### PR DESCRIPTION
Remove some superfluous quotes in the Visual Studio Code configuration.

**Status:** Ready

**Fixes:** N/A