### PR TITLE
Load the OPAM env rather than explicitly appending to `PATH`

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -175,8 +175,8 @@ function rg {
 # Homebrew
 ! test -f /opt/homebrew/bin/brew || eval "$(/opt/homebrew/bin/brew shellenv)"
 
-# Binaries installed via OPAM (such as Coq)
-export PATH="$PATH:$HOME/.opam/default/bin"
+# OPAM
+[[ ! -r "$HOME/.opam/opam-init/init.zsh" ]] || source "$HOME/.opam/opam-init/init.zsh" > /dev/null 2> /dev/null
 
 # NVM
 export NVM_DIR="$HOME/.nvm"

--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -10,6 +10,5 @@
   "[rust]": {
     "editor.tabSize": 4
   },
-  "outline.collapseItems": "alwaysCollapse",
-  "vscoq.path": "/Users/stephanboyer/.opam/default/bin/vscoqtop"
+  "outline.collapseItems": "alwaysCollapse"
 }


### PR DESCRIPTION
Load the OPAM env rather than explicitly appending to `PATH`.

**Status:** Ready

**Fixes:** N/A