### PR TITLE
Bring back the CI badge with the new URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # My dotfiles
 
+[![Build status](https://github.com/stepchowfun/dotfiles/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stepchowfun/dotfiles/actions?query=branch%3Amain)
+
 This repository contains various configuration files I use for my shell, text editor, terminal emulator, etc.
 
 ![Screenshot](https://raw.githubusercontent.com/stepchowfun/dotfiles/main/screenshot.png)


### PR DESCRIPTION
Bring back the CI badge with the new URL scheme.

**Status:** Ready

**Fixes:** N/A