### PR TITLE
Update CI actions and Toast base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.1.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/toast.yml
+++ b/toast.yml
@@ -1,4 +1,4 @@
-image: ubuntu:24.04
+image: ubuntu:26.04
 default: install
 user: user
 command_prefix: |

--- a/toast.yml
+++ b/toast.yml
@@ -65,12 +65,9 @@ tasks:
       }
       export -f zsh
 
-      # The script tries to hook up the STDIN of sudo to the TTY, but there is
-      # no TTY.
-      sudo ln -sf /dev/null /dev/tty
-
       # Avoid running into Git's `safe.directory` restriction.
       sudo chown --recursive user .
 
-      # Run the script.
-      ./install-local.sh
+      # Run the script inside a pseudo-terminal so its `/dev/tty` redirections
+      # keep working on newer Ubuntu images.
+      script --quiet --return --command ./install-local.sh /dev/null


### PR DESCRIPTION
## Summary
- update the pinned GitHub Actions versions in CI
- bump the Toast base image to `ubuntu:26.04`

## Validation
- not run locally (configuration-only change)