### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.1.0
+      uses: docker/login-action@v4.2.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Update pinned GitHub Actions versions to latest:

- `actions/checkout`: v6.0.2 → v7.0.0
- `docker/login-action`: v4.1.0 → v4.2.0

**Status:** Ready

**Fixes:** N/A