### PR TITLE
Document CI checks for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contributing
 
 Thank you for your interest in contributing! You can contribute by filing [issues](https://github.com/stepchowfun/dotfiles/issues) and submitting [pull requests](https://github.com/stepchowfun/dotfiles/pulls). Please observe our [code of conduct](https://github.com/stepchowfun/dotfiles/blob/main/CODE_OF_CONDUCT.md)<!-- [file:CODE_OF_CONDUCT.md] -->.
+
+If you submit a pull request, please ensure your change passes the [GitHub Actions](https://github.com/stepchowfun/dotfiles/actions) CI checks. This will be apparent from the required status check(s) in the pull request.


### PR DESCRIPTION
Add the standard note asking contributors to ensure pull requests pass the GitHub Actions checks.

**Status:** Ready

**Fixes:** N/A