### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.5.1
+      uses: docker/login-action@v4.6.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Update docker/login-action from 4.5.1 to 4.6.0. The base16-shell gitlink and 2026 copyright notice were already current.

**Status:** Ready

**Fixes:** N/A